### PR TITLE
Update to subversion 1.8.5, XML declaration to UTF-8, better package icon

### DIFF
--- a/svn/svn.nuspec
+++ b/svn/svn.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>svn</id>
     <title>Subversion for Windows</title>
-    <version>1.8.4</version>
+    <version>1.8.5</version>
     <authors>Zid Alagazam</authors>
     <owners>Brian Dukes</owners>
     <summary>Command line tools, Language bindings, and Apache httpd modules</summary>
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://raw.github.com/bdukes/Chocolatey-Packages/master/svn/icon.png</iconUrl>
+    <iconUrl>http://tomone.github.io/icons/svn.svg</iconUrl>
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/svn/tools/chocolateyInstall.ps1
+++ b/svn/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = 'svn'
 $installerType = 'msi'
-$url = 'http://sourceforge.net/projects/win32svn/files/1.8.4/Setup-Subversion-1.8.4.msi'
+$url = 'http://sourceforge.net/projects/win32svn/files/1.8.5/Setup-Subversion-1.8.5.msi'
 $url64 = $url
 $silentArgs = '/quiet'
 $validExitCodes = @(0)


### PR DESCRIPTION
The previous package icon had only 48 × 48 px, so I’ve included a better one.
