### PR TITLE
bump pscx to 3.2.0

### DIFF
--- a/pscx/pscx.nuspec
+++ b/pscx/pscx.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>pscx</id>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <title>PowerShell Community Extensions</title>
         <authors>PowerShell Community Extensions</authors>
         <owners>yannisgu, bdukes</owners>

--- a/pscx/tools/chocolateyInstall.ps1
+++ b/pscx/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
-$packageName = 'pscx'
+﻿$packageName = 'pscx'
 $installerType = 'msi'
-$url = 'https://pscx.codeplex.com/downloads/get/744915'
+$url = 'https://pscx.codeplex.com/downloads/get/923562'
 $url64 = $url
 $silentArgs = '/quiet'
 $validExitCodes = @(0)


### PR DESCRIPTION
bump version to 3.2.0
the old MSI appears to have been taken down so currently this is not installing
