### PR TITLE
imagemagick - fixed regex replace for fallback mirror links

### DIFF
--- a/automatic/imagemagick.app - legacy/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app - legacy/tools/chocolateyInstall.ps1
@@ -15,8 +15,8 @@ try {
     Get-WebHeaders $packageArgs.url
 }
 catch {
-    $packageArgs.url = $packageArgs.url -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
-    $packageArgs.url64 = $packageArgs.url64 -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url = $packageArgs.url -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url64 = $packageArgs.url64 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
 }
 
 if ($env:chocolateyPackageParameters) {

--- a/automatic/imagemagick.app/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app/tools/chocolateyInstall.ps1
@@ -15,8 +15,8 @@ try {
     Get-WebHeaders $packageArgs.url
 }
 catch {
-    $packageArgs.url = $packageArgs.url -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
-    $packageArgs.url64 = $packageArgs.url64 -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url = $packageArgs.url -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url64 = $packageArgs.url64 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
 }
 
 if ($env:chocolateyPackageParameters) {
@@ -28,7 +28,7 @@ if ($env:chocolateyPackageParameters) {
     if ($packageParams.LegacySupport) {
         $additionalTasks += 'legacy_support'
     }
-    
+
     if ($additionalTasks.length -gt 0) {
         $packageArgs.silentArgs = $packageArgs.silentArgs + ' /MERGETASKS=' + ($additionalTasks -join ',')
     }

--- a/automatic/imagemagick.tool - legacy/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.tool - legacy/tools/chocolateyInstall.ps1
@@ -13,8 +13,8 @@ try {
     Get-WebHeaders $packageArgs.url
 }
 catch {
-    $packageArgs.url = $packageArgs.url -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
-    $packageArgs.url64 = $packageArgs.url64 -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url = $packageArgs.url -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url64 = $packageArgs.url64 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
 }
 
 Install-ChocolateyZipPackage @packageArgs

--- a/automatic/imagemagick.tool/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.tool/tools/chocolateyInstall.ps1
@@ -13,8 +13,8 @@ try {
     Get-WebHeaders $packageArgs.url
 }
 catch {
-    $packageArgs.url = $packageArgs.url -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
-    $packageArgs.url64 = $packageArgs.url64 -replace 'https://www.imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url = $packageArgs.url -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
+    $packageArgs.url64 = $packageArgs.url64 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'http://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
 }
 
 Install-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
ImageMagick sometimes only keeps recent versions within the official binaries directory.  Fixed `regex` matching for fallback mirror links.