### PR TITLE
ImageMagick move to internal and other updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ gist.md
 update_info.xml
 Update-AUPackages.md
 Update-History.md
+*.exe

--- a/automatic/imagemagick.app/imagemagick.app.nuspec
+++ b/automatic/imagemagick.app/imagemagick.app.nuspec
@@ -14,10 +14,12 @@ This package installs the dynamic 16 bits-per-pixel (with high dynamic-range ima
 
 You can add -PackageParameters InstallDevelopmentHeaders=true to the choco install command in order to install the development headers and libraries for C and C++
 
-You can add -PackageParameters LegacySupport=true to the choco install command in order to install the legacy utilities (e.g. convert)]]></description>
+You can add -PackageParameters LegacySupport=true to the choco install command in order to install the legacy utilities (e.g. convert)
+
+You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon]]></description>
     <projectUrl>https://www.imagemagick.org/</projectUrl>
     <tags>imagemagick images picture graphics convert admin</tags>
-    <copyright><![CDATA[© ImageMagick Studio LLC]]></copyright>
+    <copyright><![CDATA[© 2020 ImageMagick Studio LLC]]></copyright>
     <licenseUrl>https://www.imagemagick.org/script/license.php</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/bdukes/Chocolatey-Packages/c8afd71590e0567e3c66e2a70bd6e4ca61f15715/icons/imagemagick.png</iconUrl>
@@ -33,5 +35,6 @@ You can add -PackageParameters LegacySupport=true to the choco install command i
   </metadata>
   <files>
     <file src="tools\**" target="tools\" />
+    <file src="legal\**" target="legal\" />
   </files>
 </package>

--- a/automatic/imagemagick.app/imagemagick.app.nuspec
+++ b/automatic/imagemagick.app/imagemagick.app.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>imagemagick.app</id>
     <title>ImageMagick (Install)</title>
@@ -18,11 +18,11 @@ You can add -PackageParameters LegacySupport=true to the choco install command i
 
 You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon]]></description>
     <projectUrl>https://www.imagemagick.org/</projectUrl>
-    <tags>imagemagick images picture graphics convert admin</tags>
+    <tags>imagemagick images picture graphics convert</tags>
     <copyright><![CDATA[© 2020 ImageMagick Studio LLC]]></copyright>
     <licenseUrl>https://www.imagemagick.org/script/license.php</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/bdukes/Chocolatey-Packages/c8afd71590e0567e3c66e2a70bd6e4ca61f15715/icons/imagemagick.png</iconUrl>
+    <iconUrl>https://cdn.staticaly.com/gh/bdukes/Chocolatey-Packages/c8afd71590e0567e3c66e2a70bd6e4ca61f15715/icons/imagemagick.png</iconUrl>
     <packageSourceUrl>https://github.com/bdukes/Chocolatey-Packages</packageSourceUrl>
     <releaseNotes>https://www.imagemagick.org/script/changelog.php</releaseNotes>
     <docsUrl>https://www.imagemagick.org/script/command-line-processing.php</docsUrl>

--- a/automatic/imagemagick.app/legal/LICENSE.txt
+++ b/automatic/imagemagick.app/legal/LICENSE.txt
@@ -1,0 +1,107 @@
+From: https://github.com/ImageMagick/ImageMagick/blob/master/LICENSE
+
+--------------------
+
+Before we get to the text of the license, lets just review what the license says in simple terms:
+
+It allows you to:
+
+  * freely download and use ImageMagick software, in whole or in part, for personal, company internal, or commercial purposes;
+  * use ImageMagick software in packages or distributions that you create;
+  * link against a library under a different license;
+  * link code under a different license against a library under this license;
+  * merge code into a work under a different license;
+  * extend patent grants to any code using code under this license;
+  * and extend patent protection.
+
+It forbids you to:
+
+  * redistribute any piece of ImageMagick-originated software without proper attribution;
+  * use any marks owned by ImageMagick Studio LLC in any way that might state or imply that ImageMagick Studio LLC endorses your distribution;
+  * use any marks owned by ImageMagick Studio LLC in any way that might state or imply that you created the ImageMagick software in question.
+
+It requires you to:
+
+  * include a copy of the license in any redistribution you may make that includes ImageMagick software;
+  * provide clear attribution to ImageMagick Studio LLC for any distributions that include ImageMagick software.
+
+It does not require you to:
+
+  * include the source of the ImageMagick software itself, or of any modifications you may have made to it, in any redistribution you may assemble that includes it;
+  * submit changes that you make to the software back to the ImageMagick Studio LLC (though such feedback is encouraged).
+
+A few other clarifications include:
+
+  * ImageMagick is freely available without charge;
+  * you may include ImageMagick on a DVD as long as you comply with the terms of the license;
+  * you can give modified code away for free or sell it under the terms of the ImageMagick license or distribute the result under a different license, but you need to acknowledge the use of the ImageMagick software;
+  * the license is compatible with the GPL V3.
+  * when exporting the ImageMagick software, review its export classification.
+
+Terms and Conditions for Use, Reproduction, and Distribution
+
+The legally binding and authoritative terms and conditions for use, reproduction, and distribution of ImageMagick follow:
+
+Copyright 1999-2020 ImageMagick Studio LLC, a non-profit organization dedicated to making software imaging solutions freely available.
+
+1. Definitions.
+
+License shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+Licensor shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+Legal Entity shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, control means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+You (or Your) shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+Source form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+Object form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+Work shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+Derivative Works shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+Contribution shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as Not a Contribution.
+
+Contributor shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+  * You must give any other recipients of the Work or Derivative Works a copy of this License; and
+  * You must cause any modified files to carry prominent notices stating that You changed the files; and
+  * You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+  * If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+How to Apply the License to your Work
+
+To apply the ImageMagick License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information (don't include the brackets). The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the ImageMagick License (the "License"); you may not use
+   this file except in compliance with the License.  You may obtain a copy
+   of the License at
+
+     https://imagemagick.org/script/license.php
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+   License for the specific language governing permissions and limitations
+   under the License.

--- a/automatic/imagemagick.app/legal/VERIFICATION.txt
+++ b/automatic/imagemagick.app/legal/VERIFICATION.txt
@@ -1,0 +1,20 @@
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+Package can be verified like this:
+
+1. Go to
+
+   x32: https://imagemagick.org/download/binaries/ImageMagick-7.0.10-34-Q16-x86-dll.exe
+   x64: https://imagemagick.org/download/binaries/ImageMagick-7.0.10-34-Q16-HDRI-x64-dll.exe
+
+   to download the installer.
+
+2. You can use one of the following methods to obtain the SHA256 checksum:
+   - Use powershell function 'Get-FileHash'
+   - Use Chocolatey utility 'checksum.exe'
+
+   checksum32: DB5DEDCE7EB31F648FA3148CB8D8F2A8B3B7C59DBCAE359220DE75FA442E2BE6
+   checksum64: 9421E6DB6F17C8A8A5D52828504D8440491F9E058A02ACA6A2FBA7995DE862B4

--- a/automatic/imagemagick.app/update.ps1
+++ b/automatic/imagemagick.app/update.ps1
@@ -1,16 +1,18 @@
-import-module au
+﻿import-module au
 
 function global:au_SearchReplace {
-    @{
-        'tools\chocolateyInstall.ps1' = @{
-            "(^\s*url64\s*=\s*)('.*')"         = "`$1'$($Latest.Url64)'"
-            "(^\s*url\s*=\s*)('.*')"           = "`$1'$($Latest.Url32)'"
-            "(^\s*fallbackUrl64\s*=\s*)('.*')" = "`$1'$($Latest.FallbackUrl64)'"
-            "(^\s*fallbackUrl\s*=\s*)('.*')"   = "`$1'$($Latest.FallbackUrl32)'"
-            "(^\s*checksum\s*=\s*)('.*')"      = "`$1'$($Latest.Checksum32)'"
-            "(^\s*checksum64\s*=\s*)('.*')"    = "`$1'$($Latest.Checksum64)'"
+    @{        
+        ".\legal\VERIFICATION.txt" = @{
+          "(?i)(\s+x32:).*"            = "`${1} $($Latest.URL32)"
+          "(?i)(\s+x64:).*"            = "`${1} $($Latest.URL64)"
+          "(?i)(checksum32:).*"        = "`${1} $($Latest.Checksum32)"
+          "(?i)(checksum64:).*"        = "`${1} $($Latest.Checksum64)"
         }
      }
+}
+
+function global:au_BeforeUpdate {
+     Get-RemoteFiles -Purge
 }
 
 function global:au_GetLatest {
@@ -20,8 +22,6 @@ function global:au_GetLatest {
     $re64 = "^http.+ImageMagick-(\d+\.\d+\.\d+-\d+)-Q16-HDRI-x64-dll.exe$"
     $url32 = $download_page.links | ? href -match $re32 | select -First 1 -expand href
     $url64 = $download_page.links | ? href -match $re64 | select -First 1 -expand href
-    $fallbackUrl32 =  $url32 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
-    $fallbackUrl64 =  $url64 -replace 'https?://(?:www\.)?imagemagick.org/download/binaries/', 'https://ftp.icm.edu.pl/pub/graphics/ImageMagick/binaries/'
 
     $versionMatch = $url64 | select-string -Pattern $re64
     $version = $versionMatch.Matches[0].Groups[1].Value -replace '-', '.'
@@ -30,9 +30,7 @@ function global:au_GetLatest {
         Url32 = $url32
         Url64 = $url64
         Version = $version
-        FallbackUrl32 = $fallbackUrl32
-        FallbackUrl64 = $fallbackUrl64
     }
 }
 
-update
+update -ChecksumFor none


### PR DESCRIPTION
Hey, @bdukes 

Fixes #35 
Fixes #28 
Might fix #16 

- Includes the installers inside the package
  - `.gitignore`s `.exe` files
  - Adds `legal` folder for required `LICENSE.txt` and `VERIFICATION.txt` files
  - Removes url related items from install script.
  - updates `update.ps1` to download the files, and to replace links in `VERIFICATION.txt` 
- Adds `NoDesktop` package parameter.
- Misc other updates.
  - Updates the `.nuspec` schema
  - Changes to staticaly.com for the icon link because rawgit is shut down.
  - Removes admin tag, which is no longer recommended. 
  - Replace `wonâ€™t` with `won't`
  - Add `softwareName` to `packageArgs`, should help uninstall be more reliable.