### PR TITLE
ImageMagick - InstallOldFFmpeg

### DIFF
--- a/automatic/imagemagick.app/imagemagick.app.nuspec
+++ b/automatic/imagemagick.app/imagemagick.app.nuspec
@@ -18,7 +18,7 @@ You can add -PackageParameters LegacySupport=true to the choco install command i
 
 You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon
     
-You can add -PackageParameters InstallOldFFmpeg=true to the choco install command to install FFmpeg 4.2.3 (2020), included with ImageMagick]]></description>
+You can add -PackageParameters InstallOldFFmpeg=true to the choco install command to install the FFmpeg included with ImageMagick]]></description>
     <projectUrl>https://www.imagemagick.org/</projectUrl>
     <tags>imagemagick images picture graphics convert</tags>
     <copyright><![CDATA[© 2020 ImageMagick Studio LLC]]></copyright>

--- a/automatic/imagemagick.app/imagemagick.app.nuspec
+++ b/automatic/imagemagick.app/imagemagick.app.nuspec
@@ -16,7 +16,9 @@ You can add -PackageParameters InstallDevelopmentHeaders=true to the choco insta
 
 You can add -PackageParameters LegacySupport=true to the choco install command in order to install the legacy utilities (e.g. convert)
 
-You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon]]></description>
+You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon
+    
+You can add -PackageParameters InstallOldFFmpeg=true to the choco install command to install FFmpeg 4.2.3 (2020), included with ImageMagick]]></description>
     <projectUrl>https://www.imagemagick.org/</projectUrl>
     <tags>imagemagick images picture graphics convert</tags>
     <copyright><![CDATA[© 2020 ImageMagick Studio LLC]]></copyright>

--- a/automatic/imagemagick.app/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app/tools/chocolateyInstall.ps1
@@ -23,18 +23,18 @@ if ($env:chocolateyPackageParameters) {
     if ($packageParams.NoDesktop) {
         $additionalTasks += '!desktop_icon'
     }
-    if ($false -eq $(packageParams.InstallOldFFmpeg) {
+    if (-not $packageParams.InstallOldFFmpeg) {
         $additionalTasks += '!install_FFmpeg'
-        # If FFmpeg is already present, warn user of PATH conflicts
-        if ($null -eq -not $(Get-Command ffmpeg)) {
-            Write-Warning "FFmpeg is already present on the system. Installing ImageMagicks's FFmpeg will cause a PATH conflict and ImageMagick's outdated FFmpeg will be selected."
+        # If NOT installing FFmpeg when NOT present, warn of unavailable features. Suggest 'choco install ffmpeg'.
+        if (-not (Get-Command ffmpeg -ErrorAction SilentlyContinue)) {
+            Write-Warning "FFmpeg is not present on this system and ImageMagick's outdated FFmpeg has not been enabled. Some ImageMagick features will be unavailable. Install FFmpeg via 'choco install ffmpeg'."
         }
     }
-    # If NOT installing FFmpeg when NOT present, warn of unavailable features. Suggest 'choco install ffmpeg'.
-    elseif ($null -eq $(Get-Command ffmpeg)){
-        Write-Warning "FFmpeg is not present on this system and ImageMagick's outdated FFmpeg has not been enabled. Some ImageMagick features will be unavailable. Install FFmpeg via 'choco install ffmpeg'."
+    # If FFmpeg is already present, warn user of PATH conflicts
+    elseif (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
+        Write-Warning "FFmpeg is already present on the system. Installing ImageMagicks's FFmpeg will cause a PATH conflict and ImageMagick's outdated FFmpeg will be selected."
     }
-    
+
     if ($additionalTasks.length -gt 0) {
         $packageArgs.silentArgs = $packageArgs.silentArgs + ' /MERGETASKS=' + ($additionalTasks -join ',')
     }

--- a/automatic/imagemagick.app/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app/tools/chocolateyInstall.ps1
@@ -23,7 +23,18 @@ if ($env:chocolateyPackageParameters) {
     if ($packageParams.NoDesktop) {
         $additionalTasks += '!desktop_icon'
     }
-
+    if ($false -eq $(packageParams.InstallOldFFmpeg) {
+        $additionalTasks += '!install_FFmpeg'
+        # If FFmpeg is already present, warn user of PATH conflicts
+        if ($null -eq -not $(Get-Command ffmpeg)) {
+            Write-Warning "FFmpeg is already present on the system. Installing ImageMagicks's FFmpeg will cause a PATH conflict and ImageMagick's outdated FFmpeg will be selected."
+        }
+    }
+    # If NOT installing FFmpeg when NOT present, warn of unavailable features. Suggest 'choco install ffmpeg'.
+    elseif ($null -eq $(Get-Command ffmpeg)){
+        Write-Warning "FFmpeg is not present on this system and ImageMagick's outdated FFmpeg has not been enabled. Some ImageMagick features will be unavailable. Install FFmpeg via 'choco install ffmpeg'."
+    }
+    
     if ($additionalTasks.length -gt 0) {
         $packageArgs.silentArgs = $packageArgs.silentArgs + ' /MERGETASKS=' + ($additionalTasks -join ',')
     }

--- a/automatic/imagemagick/imagemagick.nuspec
+++ b/automatic/imagemagick/imagemagick.nuspec
@@ -12,7 +12,13 @@
 
 This package installs the dynamic 16 bits-per-pixel (with high dynamic-range imaging enabled for x64) version of ImageMagick.
 
-You can add -PackageParameters InstallDevelopmentHeaders=true to the choco install command in order to install the development headers and libraries for C and C++]]></description>
+You can add -PackageParameters InstallDevelopmentHeaders=true to the choco install command in order to install the development headers and libraries for C and C++
+      
+You can add -PackageParameters LegacySupport=true to the choco install command in order to install the legacy utilities (e.g. convert)
+
+You can add -PackageParameters NoDesktop=true to the choco install command in order to not create a desktop icon
+    
+You can add -PackageParameters InstallOldFFmpeg=true to the choco install command to install the FFmpeg included with ImageMagick]]></description>
     <projectUrl>https://www.imagemagick.org/</projectUrl>
     <tags>imagemagick images picture graphics convert admin</tags>
     <copyright><![CDATA[© ImageMagick Studio LLC]]></copyright>


### PR DESCRIPTION
Closes #41 

TODO: propogate to...
- [x] ./automatic/imagemagick
- [x] ./automatic/imagemagick.tool

+ Task 'install_FFmpeg' is disabled by default.
+ Assigning true to PackageParameter 'InstallOldFFmpeg' will enable task 'install_FFmpeg'
+ Setting PackageParameter 'InstallOldFFmpeg' to
   'true' (-PackageParameters InstallOldFFmpeg=true)
  will install the FFmpeg included with ImageMagick.
+ If installing IM's FFmpeg when FFmpeg is already
  present in PATH, a warning will be displayed to the user.
+ If NOT installing IM's FFmpeg when FFmpeg is NOT present, 
  warn the user that some features will be unavailable
   and recommend installing FFmpeg via `choco install ffmpeg`

? Should we ignore InstallOldFFmpeg when FFmpeg is already present? 

Further research is necessary to determine which features
  are dependent on FFmpeg 4.2.3 at the time of this commit.
  The aforementioned version lacks many codecs and filters,
  but later releases may have dropped features or changed
   implementations, breaking IM functionality.