### PR TITLE
Patch for ImageMagick

### DIFF
--- a/automatic/imagemagick.app - legacy/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app - legacy/tools/chocolateyInstall.ps1
@@ -26,20 +26,16 @@ if ($env:chocolateyPackageParameters) {
     }
 }
 
-try {
-    # Uninstall older version of imagemagick, otherwise the installation won’t be silent.
-    $regPath = 'HKLM:\SOFTWARE\ImageMagick\Current';
-    if ($env:chocolateyForceX86) {
-        $regPath = 'HKLM:\SOFTWARE\Wow6432Node\ImageMagick\Current';
-    }
-    if (Test-Path $regPath) {
-        $uninstallPath = (Get-ItemProperty -Path $regPath).BinPath;
-        $uninstallFilePath = "$uninstallPath\unins000.exe";
-        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $uninstallFilePath;
-    }
-} catch {
-    Write-Warning "$packageName uninstallation failed, with message $($_.Exception.Message)";
-    Write-Warning "$packageName installation may not be silent";
+#Uninstall old version if present
+$UninstallKey = $(Get-UninstallRegistryKey -softwareName $packageArgs.softwareName).UninstallString
+
+if ($UninstallKey.count -eq 1) {
+    # foreach ($key in $UninstallKey){
+        Write-Host "Uninstalling previous version is required for silent upgrade"
+        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $UninstallKey
+    # }
+}elseif ($UninstallKey.count -gt 1) {
+    throw "Uninstallation of the old version was aborted because they are too much uninstall entries. List of entries : $UninstallKey"
 }
 
 Write-Verbose "Installing with arguments: $($packageArgs.silentArgs)";

--- a/automatic/imagemagick.app - legacy/tools/chocolateyUninstall.ps1
+++ b/automatic/imagemagick.app - legacy/tools/chocolateyUninstall.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop';
+
+$packageArgs = @{
+  packageName    = $Env:ChocolateyPackageName
+  installerType  = 'exe'
+  silentArgs     = '/VERYSILENT'
+  validExitCodes = @(0)
+  softwareName   = 'ImageMagick*'
+}
+   
+$UninstallKey = $(Get-UninstallRegistryKey -softwareName $packageArgs.softwareName).UninstallString
+
+if ($UninstallKey.count -eq 1) {
+        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $UninstallKey
+}elseif ($UninstallKey.count -gt 1) {
+    throw "Uninstallation was aborted because they are too much uninstall entries. List of entries : $UninstallKey"
+}

--- a/automatic/imagemagick.app/tools/chocolateyInstall.ps1
+++ b/automatic/imagemagick.app/tools/chocolateyInstall.ps1
@@ -40,20 +40,16 @@ if ($env:chocolateyPackageParameters) {
     }
 }
 
-try {
-    # Uninstall older version of imagemagick, otherwise the installation won't be silent.
-    $regPath = 'HKLM:\SOFTWARE\ImageMagick\Current'
-    if ($env:chocolateyForceX86) {
-        $regPath = 'HKLM:\SOFTWARE\Wow6432Node\ImageMagick\Current'
-    }
-    if (Test-Path $regPath) {
-        $uninstallPath = (Get-ItemProperty -Path $regPath).BinPath
-        $uninstallFilePath = "$uninstallPath\unins000.exe"
-        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $uninstallFilePath
-    }
-} catch {
-    Write-Warning "$packageName uninstallation failed, with message $($_.Exception.Message)"
-    Write-Warning "$packageName installation may not be silent"
+#Uninstall old version if present
+$UninstallKey = $(Get-UninstallRegistryKey -softwareName $packageArgs.softwareName).UninstallString
+
+if ($UninstallKey.count -eq 1) {
+    # foreach ($key in $UninstallKey){
+        Write-Host "Uninstalling previous version is required for silent upgrade"
+        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $UninstallKey
+    # }
+}elseif ($UninstallKey.count -gt 1) {
+    throw "Uninstallation of the old version was aborted because they are too much uninstall entries. List of entries : $UninstallKey"
 }
 
 Write-Verbose "Installing with arguments: $($packageArgs.silentArgs)"

--- a/automatic/imagemagick.app/tools/chocolateyUninstall.ps1
+++ b/automatic/imagemagick.app/tools/chocolateyUninstall.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop';
+
+$packageArgs = @{
+  packageName    = $Env:ChocolateyPackageName
+  installerType  = 'exe'
+  silentArgs     = '/VERYSILENT'
+  validExitCodes = @(0)
+  softwareName   = 'ImageMagick*'
+}
+   
+$UninstallKey = $(Get-UninstallRegistryKey -softwareName $packageArgs.softwareName).UninstallString
+
+if ($UninstallKey.count -eq 1) {
+        Uninstall-ChocolateyPackage $packageArgs.packageName $packageArgs.installerType $packageArgs.silentArgs $UninstallKey
+}elseif ($UninstallKey.count -gt 1) {
+    throw "Uninstallation was aborted because they are too much uninstall entries. List of entries : $UninstallKey"
+}


### PR DESCRIPTION
Hello, the choco package for ImageMagick does not uninstall the previous version on the latest update.
So I upgraded the verification and uninstall process.

I also add chocolateyUninstall to get a complete silent uninstall process.

Can you review and merge it if this patch works for you?

Best regards