### PR TITLE
Fix checksum for rustdesk 1.2.3

### DIFF
--- a/automatic/rustdesk.install/tools/chocolateyinstall.ps1
+++ b/automatic/rustdesk.install/tools/chocolateyinstall.ps1
@@ -6,7 +6,7 @@ $packageArgs = @{
   url            = 'https://github.com/rustdesk/rustdesk/releases/download/1.2.3/rustdesk-1.2.3-x86_64.exe'
   silentArgs     = "--silent-install"
   validExitCodes = @(0)
-  checksum       = '0856e5c8c3ee94edfddb80be160ee6857ab72d972065be86783af2c907a7cd54'
+  checksum       = '23b661d7bc171cd500d5096456905283ffe06479582b62d3bd5066633935d43e'
   checksumType   = 'sha256'
 }
 

--- a/automatic/rustdesk.portable/tools/chocolateyinstall.ps1
+++ b/automatic/rustdesk.portable/tools/chocolateyinstall.ps1
@@ -6,7 +6,7 @@ $packageArgs = @{
   packageName  = $env:ChocolateyPackageName
   fileFullPath = $exeFile
   url          = 'https://github.com/rustdesk/rustdesk/releases/download/1.2.3/rustdesk-1.2.3-x86_64.exe'
-  checksum     = '0856e5c8c3ee94edfddb80be160ee6857ab72d972065be86783af2c907a7cd54'
+  checksum     = '23b661d7bc171cd500d5096456905283ffe06479582b62d3bd5066633935d43e'
   checksumType = 'sha256'
 }
 


### PR DESCRIPTION
The checksum was calculated like this:

```
  ❯ curl -sL https://github.com/rustdesk/rustdesk/releases/download/1.2.3/rustdesk-1.2.3-x86_64.exe | sha256sum
  23b661d7bc171cd500d5096456905283ffe06479582b62d3bd5066633935d43e  -
```

Closes: bdukes/Chocolatey-Packages#51