### PR TITLE
fix(rustdesk.install): rename $packageArgs to $uninstallArgs

### DIFF
--- a/automatic/rustdesk.install/tools/chocolateyinstall.ps1
+++ b/automatic/rustdesk.install/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $url64                 = 'https://github.com/rustdesk/rustdesk/releases/download/1.4.6/rustdesk-1.4.6-x86_64.msi'
 $checksum64            = '7aad1f481b2fdf86166d082933071e7e9aaf7efd3666a4204cdc5fd2f42b0e59'
@@ -21,13 +21,13 @@ $packageArgs = @{
 if ($key.QuietUninstallString) {
   $parts = $key.QuietUninstallString -split '\s+', 2
 
-  $packageArgs = @{
+  $uninstallArgs = @{
     packageName = $env:ChocolateyPackageName
     file        = $parts[0]
     silentArgs  = $parts[1]
   }
 
-  Uninstall-ChocolateyPackage @packageArgs
+  Uninstall-ChocolateyPackage @uninstallArgs
 }
 
 # Install the new version


### PR DESCRIPTION
@bdukes 

This PR renames $packageArgs to $uninstallArgs in the uninstall block of chocolateyInstall.ps1.

Prevents the uninstall hashtable from overwriting the install args, causing upgrades always to fail.

This is a fix for this user reported [comment](https://community.chocolatey.org/packages/rustdesk.install#comment-6854527464).

Please package a new version of both rustdesk and rustdesk.install with the following version scheme:

`1.4.6.20260324`

The `rustdesk` package `rustdesk.install` dependency should be updated to the same version